### PR TITLE
Fix case of directory name.

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -2,7 +2,7 @@
 
 
 #load helper scripts
-HSLocation <- "helperScripts/"
+HSLocation <- "HelperScripts/"
 source(paste0(HSLocation, "ShinyServerFunctions.R"))
 source(paste0(HSLocation, "AssignmentTable.R"))
 source(paste0(HSLocation, "Pivot.R"))


### PR DESCRIPTION
This may not have been a problem on case-insensitive filesystems, like on macOS.